### PR TITLE
Stop using the deprecated knex.initialize

### DIFF
--- a/app/data/bookshelf/migrate.js
+++ b/app/data/bookshelf/migrate.js
@@ -1,6 +1,6 @@
 import Knex from 'knex';
 import config from '../../config/config.json';
-const knex = Knex.initialize(config.bookshelf.postgresql);
+const knex = Knex(config.bookshelf.postgresql);
 
 export default function () {
   knex.migrate.latest(config.bookshelf.migrations)


### PR DESCRIPTION
There was a warning running `gulp migrate`
```
Knex:warning - knex.initialize is deprecated, pass your config object directly to the knex module
```

This pull request removes the call to `initialize` and call the module directly (as stated in the warning) 